### PR TITLE
This commit fixes a `TypeError: whisper is not a function` error that…

### DIFF
--- a/ai/ai-service.js
+++ b/ai/ai-service.js
@@ -1,4 +1,4 @@
-const whisper = require('nodejs-whisper');
+const { whisper } = require('nodejs-whisper');
 const ffmpeg = require('fluent-ffmpeg');
 const ffmpegInstaller = require('@ffmpeg-installer/ffmpeg');
 const path = require('path');


### PR DESCRIPTION
… occurred during video caption generation.

The error was caused by an incorrect import of the `nodejs-whisper` library. The library exports a `whisper` function as a named export, but the code was attempting to use the entire module as a function.

The fix changes the import statement in `ai/ai-service.js` from `const whisper = require('nodejs-whisper');` to `const { whisper } = require('nodejs-whisper');` to correctly destructure and use the exported function.