### PR TITLE
fix(ai): correct import for nodejs-whisper

### DIFF
--- a/ai/ai-service.js
+++ b/ai/ai-service.js
@@ -1,4 +1,4 @@
-const { whisper } = require('nodejs-whisper');
+const { nodewhisper: whisper } = require('nodejs-whisper');
 const ffmpeg = require('fluent-ffmpeg');
 const ffmpegInstaller = require('@ffmpeg-installer/ffmpeg');
 const path = require('path');


### PR DESCRIPTION
The `nodejs-whisper` library exports a function named `nodewhisper`, not `whisper`. This was causing a `TypeError: whisper is not a function` during the transcription process.

This commit corrects the import in `ai/ai-service.js` by using a destructuring alias to import `nodewhisper` as `whisper`. This resolves the TypeError while minimizing changes to the rest of the file.