### PR TITLE
feat(ai): automatically download whisper model

### DIFF
--- a/ai/ai-service.js
+++ b/ai/ai-service.js
@@ -42,6 +42,7 @@ class AIService {
                         // For now, we're keeping it simple as per the original implementation.
                         const transcript = await whisper(audioPath, {
                             modelName: "base.en", // Using a specific model
+                            autoDownloadModelName: "base.en",
                             whisperOptions: {
                                 "-fp16": true, // Enable half-precision for faster processing if supported
                                 "-nt": true // No timestamps


### PR DESCRIPTION
Adds the `autoDownloadModelName` option to the whisper configuration. This allows the application to automatically download the required transcription model if it is not already present on the system.

This prevents the `[Nodejs-whisper] Error: Model file does not exist` error that occurs after the initial TypeError fix.