### PR TITLE
This removes the 'protect' middleware from the temporary GET route to…

### DIFF
--- a/Routes/aiRoute.js
+++ b/Routes/aiRoute.js
@@ -289,8 +289,8 @@ router.post('/translate-video', protect, translateVideo);
  */
 router.post('/process-translations', protect, processPendingTranslations);
 
-// TEMP: Add a GET route for manual testing
-router.get('/process-translations-manual', protect, processPendingTranslations);
+// TEMP: Add a GET route for manual testing (NO AUTH)
+router.get('/process-translations-manual', processPendingTranslations);
 
 /**
  * @swagger


### PR DESCRIPTION
… allow for easier manual testing without a token.