### PR TITLE
feat: Add video combining and silence removal feature

### DIFF
--- a/Routes/contentRoute.js
+++ b/Routes/contentRoute.js
@@ -21,9 +21,68 @@ const {
     addWatchlist,
     getWatchlist,
     removeWatchlist,
+    combineVideos,
 } = require('../controllers/contentController');
 const upload = require('../middleware/multer');
-const { protect } = require('../middleware/authmiddleware');
+const { protect, admin } = require('../middleware/authmiddleware');
+
+/**
+ * @swagger
+ * /api/content/combine:
+ *   post:
+ *     summary: Combine multiple videos and remove silences
+ *     description: Merges 2 to 5 video clips into a single video and removes silences. This is an admin-only feature.
+ *     tags: [Content]
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *               - category
+ *               - description
+ *               - credit
+ *               - videos
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: Combined Awesome Video
+ *               category:
+ *                 type: string
+ *                 example: Entertainment
+ *               description:
+ *                 type: string
+ *                 example: A fun video combined from multiple clips.
+ *               credit:
+ *                 type: string
+ *                 example: Admin Productions
+ *               videos:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   format: binary
+ *                 description: 2 to 5 video files to be combined.
+ *     responses:
+ *       201:
+ *         description: Content combined and created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Content'
+ *       400:
+ *         description: Missing fields, invalid number of files, or invalid file types.
+ *       401:
+ *         description: Unauthorized
+ *       403:
+ *         description: Admin access required
+ *       500:
+ *         description: Server error
+ */
+router.route('/combine').post(protect, admin, upload.array('videos', 5), combineVideos);
 
 /**
  * @swagger

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "express-async-handler": "^1.2.0",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^7.5.1",
+    "@remotion/renderer": "^4.0.131",
+    "fluent-ffmpeg": "^2.1.2",
     "form-data": "^4.0.4",
     "glob": "^11.0.2",
     "helmet": "^8.1.0",


### PR DESCRIPTION
This commit introduces a new feature for admins to combine multiple video clips and automatically remove silences.

A new API endpoint `POST /api/content/combine` has been created, accessible only to admins. It accepts 2 to 5 video files, merges them, processes the merged video to remove silent parts, and then uploads the final video to Cloudinary.

This version corrects a flaw in the initial implementation where only the audio track was being processed for silence removal. The new implementation uses a two-pass approach to ensure both video and audio are trimmed and synchronized.

Key changes:
- Added `fluent-ffmpeg` and `@remotion/renderer` to handle video processing.
- Created a new route in `Routes/contentRoute.js` with admin-only access control.
- Implemented the `combineVideos` controller function in `controllers/contentController.js`.
- The processing now involves:
  1. Merging multiple video inputs.
  2. Using `@remotion/renderer`'s `getSilentParts` to detect audible segments.
  3. Generating a complex `ffmpeg` filtergraph to trim and concatenate the audible video and audio segments.
- The final video is uploaded to Cloudinary, and a new content document is created in the database.
- Includes robust error handling and cleanup of temporary files.