### PR TITLE
feat: Add sign-in/up with Google option

### DIFF
--- a/Routes/userRoute.js
+++ b/Routes/userRoute.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const passport = require('passport');
 
 const upload = require('../middleware/multer');
 const {
@@ -20,6 +21,7 @@ const {
   getUserHistory,
   markPrivacyPolicyAsRead,
   forgetPassword,
+  googleAuthCallback,
 } = require('../controllers/userController');
 const { protect } = require('../middleware/authmiddleware');
 
@@ -778,5 +780,13 @@ router.route('/policy/:userId').patch(protect, markPrivacyPolicyAsRead);
  *         description: Server error
  */
 router.post('/forget-password', forgetPassword);
+
+router.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+router.get(
+  '/auth/google/callback',
+  passport.authenticate('google', { failureRedirect: '/', session: false }),
+  googleAuthCallback
+);
 
 module.exports = router;

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,0 +1,44 @@
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const mongoose = require('mongoose');
+const User = require('../models/userModel');
+
+module.exports = function(passport) {
+  passport.use(
+    new GoogleStrategy(
+      {
+        clientID: process.env.GOOGLE_CLIENT_ID,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+        callbackURL: '/api/users/auth/google/callback',
+      },
+      async (accessToken, refreshToken, profile, done) => {
+        const newUser = {
+          googleId: profile.id,
+          name: profile.displayName,
+          email: profile.emails[0].value,
+          profileImage: profile.photos[0].value,
+        };
+
+        try {
+          let user = await User.findOne({ googleId: profile.id });
+
+          if (user) {
+            done(null, user);
+          } else {
+            user = await User.create(newUser);
+            done(null, user);
+          }
+        } catch (err) {
+          console.error(err);
+        }
+      }
+    )
+  );
+
+  passport.serializeUser((user, done) => {
+    done(null, user.id);
+  });
+
+  passport.deserializeUser((id, done) => {
+    User.findById(id, (err, user) => done(err, user));
+  });
+};

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1113,6 +1113,23 @@ const forgetPassword = async (req, res) => {
     res.status(500).json({ message: error.message });
   }
 };
+const googleAuthCallback = asyncHandler(async (req, res) => {
+    const token = generateToken(req.user._id, req.user.role);
+    res.json({
+        _id: req.user._id,
+        name: req.user.name,
+        email: req.user.email,
+        role: req.user.role,
+        profileImage: req.user.profileImage,
+        cloudinary_id: req.user.cloudinary_id,
+        likes: req.user.likes,
+        watchlist: req.user.watchlist,
+        history: req.user.history,
+        verified: req.user.isEmailVerified,
+        hasReadPrivacyPolicy: req.user.hasReadPrivacyPolicy,
+        token: token
+    });
+});
  
  module.exports = {
     getUser,
@@ -1131,5 +1148,6 @@ const forgetPassword = async (req, res) => {
     getLikedContents,
     saveContentToHistory,
     getUserHistory,
-    markPrivacyPolicyAsRead 
+    markPrivacyPolicyAsRead,
+    googleAuthCallback
  }

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -15,7 +15,9 @@ const userSchema = new mongoose.Schema(
         },
         password: {
             type: String,
-            required: [true, 'Please enter your password'],
+        },
+        googleId: {
+            type: String,
         },
         role: {
             type: String,

--- a/server.js
+++ b/server.js
@@ -11,7 +11,13 @@ const compression = require('compression'); // Add compression
 const mongoSanitize = require('express-mongo-sanitize'); // Add input sanitizer
 
 const app = express();
+const passport = require('passport');
 const port = process.env.PORT || 5000;
+
+// Passport config
+require('./config/passport')(passport);
+
+app.use(passport.initialize());
 
 // Security: Set secure HTTP headers
 app.use(helmet());


### PR DESCRIPTION
This commit adds the functionality for users to sign in or sign up using their Google account.

The changes include:
- Modifying the user model to include a `googleId` and make the password optional.
- Configuring Passport.js with the Google OAuth 2.0 strategy.
- Adding new routes for initiating Google authentication and handling the callback.
- Implementing a new controller function to handle the Google authentication callback, which finds or creates a user and returns a JWT token.
- Integrating Passport.js into the main server file.