### PR TITLE
fix: Change scope parameter to a string for Google OAuth

### DIFF
--- a/Routes/userRoute.js
+++ b/Routes/userRoute.js
@@ -781,7 +781,7 @@ router.route('/policy/:userId').patch(protect, markPrivacyPolicyAsRead);
  */
 router.post('/forget-password', forgetPassword);
 
-router.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+router.get('/auth/google', passport.authenticate('google', { scope: 'profile email' }));
 
 router.get(
   '/auth/google/callback',


### PR DESCRIPTION
This commit fixes a bug in the Google OAuth flow where the `scope` parameter was being sent as an array instead of a space-separated string, causing a `400 invalid_request` error from Google.

The `scope` option in the `passport.authenticate` call in `Routes/userRoute.js` has been changed from `['profile', 'email']` to `'profile email'`.