### PR TITLE
fix(auth): add scope to google oauth strategy

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -9,6 +9,7 @@ module.exports = function(passport) {
         clientID: process.env.GOOGLE_CLIENT_ID,
         clientSecret: process.env.GOOGLE_CLIENT_SECRET,
         callbackURL: '/api/users/auth/google/callback',
+        scope: ['profile', 'email'],
       },
       async (accessToken, refreshToken, profile, done) => {
         const newUser = {


### PR DESCRIPTION
The Google OAuth flow was failing with a `400: invalid_request` error because the `scope` parameter was missing from the authentication request.

This change adds the `scope` parameter to the `GoogleStrategy` configuration in `config/passport.js`, requesting the `profile` and `email` scopes. This resolves the error and allows the Google authentication to proceed correctly.