### PR TITLE
fix(auth): resolve redirect_uri_mismatch for google oauth

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -8,7 +8,7 @@ module.exports = function(passport) {
       {
         clientID: process.env.GOOGLE_CLIENT_ID,
         clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-        callbackURL: '/api/users/auth/google/callback',
+        callbackURL: process.env.GOOGLE_CALLBACK_URL,
         scope: ['profile', 'email'],
       },
       async (accessToken, refreshToken, profile, done) => {

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const compression = require('compression'); // Add compression
 const mongoSanitize = require('express-mongo-sanitize'); // Add input sanitizer
 
 const app = express();
+app.set('trust proxy', 1); // Trust the first proxy
 const passport = require('passport');
 const port = process.env.PORT || 5000;
 


### PR DESCRIPTION
This commit resolves a `redirect_uri_mismatch` error that occurred when using Google OAuth on the Heroku deployment.

The error was caused by two issues:
1. The Express application was not aware it was behind a proxy, causing it to generate `http://` URLs instead of `https://`.
2. The callback URL was not using the correct absolute URL for the production environment.

This has been fixed by:
- Adding `app.set('trust proxy', 1);` to `server.js` to make Express proxy-aware.
- Updating the GoogleStrategy in `config/passport.js` to use the `GOOGLE_CALLBACK_URL` environment variable, allowing for environment-specific callback URLs.