### PR TITLE
feat: Compress translated videos before uploading

### DIFF
--- a/utils/videoCompressor.js
+++ b/utils/videoCompressor.js
@@ -22,7 +22,7 @@ function compressVideo(inputPath, outputPath) {
       '-preset',
       'medium', // Encoding speed/quality trade-off
       '-crf',
-      '28', // Constant Rate Factor (higher value = lower quality, smaller file)
+      '23', // Constant Rate Factor (lower value = higher quality)
       '-c:a',
       'aac', // Audio codec: AAC
       '-b:a',


### PR DESCRIPTION
Introduces a video compression step to the translation processing workflow. This addresses issues where large translated video files were failing to upload to Cloudinary.

- Adds a `compressVideo` utility using ffmpeg with a CRF of 23 for a good balance of size and quality.
- Modifies the `processPendingTranslations` controller to compress downloaded videos before uploading them.
- Improves the cleanup logic to ensure both original and compressed temporary files are deleted.