### PR TITLE
Fix: Synchronize package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "mime-types": "^3.0.1",
         "mongoose": "^8.0.3",
         "multer": "^1.4.5-lts.1",
+        "multer-storage-cloudinary": "^4.0.0",
         "nodemailer": "^6.9.14",
         "nodemon": "^3.1.3",
         "passport": "^0.7.0",
@@ -3360,6 +3361,15 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/multer-storage-cloudinary": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multer-storage-cloudinary/-/multer-storage-cloudinary-4.0.0.tgz",
+      "integrity": "sha512-25lm9R6o5dWrHLqLvygNX+kBOxprzpmZdnVKH4+r68WcfCt8XV6xfQaMuAg+kUE5Xmr8mJNA4gE0AcBj9FJyWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "cloudinary": "^1.21.0"
       }
     },
     "node_modules/negotiator": {


### PR DESCRIPTION
Regenerate the `package-lock.json` file to bring it in sync with `package.json`.

This fixes the Heroku build failure (`npm lockfile is not in sync`) that occurred because new dependencies (`bullmq`, `ioredis`, `multer-storage-cloudinary`) were added to `package.json` without updating the lockfile.