### PR TITLE
Feat: Implement direct client-side uploads and background processing

### DIFF
--- a/Routes/contentRoute.js
+++ b/Routes/contentRoute.js
@@ -6,7 +6,8 @@ const {
     getTopTenContent,
     getRecommendedContent,
     getRecentCreatorContent,
-    createContent, 
+    createContent,
+    generateUploadSignature,
     addComment,
     getComments,
     updateContent, 
@@ -197,7 +198,40 @@ router.route('/combine').post(protect, admin, combineVideosByIds);
  *       500:
  *         description: Server error
  */
-router.route('/').get(getContent);    
+router.route('/').get(getContent);
+
+/**
+ * @swagger
+ * /api/content/signature:
+ *   post:
+ *     summary: Generate a signature for direct client-side uploads
+ *     description: Creates a secure, one-time signature that the client can use to upload a file directly to Cloudinary. This is the first step in the direct upload process.
+ *     tags: [Content]
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Signature generated successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 signature:
+ *                   type: string
+ *                   example: "a1b2c3d4e5f6..."
+ *                 timestamp:
+ *                   type: number
+ *                   example: 1678886400
+ *                 api_key:
+ *                   type: string
+ *                   example: "123456789012345"
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Server error
+ */
+router.route('/signature').post(protect, generateUploadSignature);
 
 /**
  * @swagger
@@ -283,7 +317,7 @@ router.route('/').get(getContent);
  *       500:
  *         description: Server error during upload initiation.
  */
-router.route('/').post(protect, upload.array('files', 2), createContent);
+router.route('/').post(protect, createContent);
 
 
 /**


### PR DESCRIPTION
This commit introduces a robust, scalable architecture for handling large file uploads to prevent server timeouts (Heroku H28 error).

The solution is comprised of three main parts:
1.  **Direct Client-Side Uploads:** The application now uses a signature-based, direct-to-Cloudinary upload flow. A new endpoint (`/api/content/signature`) provides the client with a secure token to upload files directly to Cloudinary, bypassing the Heroku server entirely for the large file transfer. This frees up the web dyno from handling the upload stream.

2.  **JSON-based Content Creation:** The primary content creation endpoint (`/api/content`) has been refactored to accept a simple JSON payload containing the Cloudinary upload metadata, rather than a multipart file upload.

3.  **Background Job Queue:** A background worker using BullMQ and Redis processes all post-upload tasks (AI analysis, database updates, etc.) asynchronously. This ensures the API responds immediately and long-running tasks do not block the web server.