### PR TITLE
fix(content): Correctly authorize content creation for creators

### DIFF
--- a/controllers/contentController.js
+++ b/controllers/contentController.js
@@ -297,10 +297,11 @@ const getContentById = asyncHandler(async (req, res) => {
 const createContent = asyncHandler(async (req, res) => {
     try {
         // The file data now comes from the client after a direct upload to Cloudinary
-        const { title, category, description, credit, userId, previewStart, previewEnd, languageCode, video, thumbnail } = req.body;
+        const { title, category, description, credit, previewStart, previewEnd, languageCode, video, thumbnail } = req.body;
+        const userId = req.user.id; // Use the authenticated user's ID
 
         // 1. Initial Validation
-        if (!title || !category || !description || !credit || !userId || !video) {
+        if (!title || !category || !description || !credit || !video) {
             return res.status(400).json({ error: 'Important fields, including video data, are missing!' });
         }
         if (!video.public_id || !video.url) {
@@ -316,9 +317,6 @@ const createContent = asyncHandler(async (req, res) => {
         const user = await userSchema.findById(userId);
         if (!user || (user.role !== 'creator' && user.role !== 'admin')) {
             return res.status(403).json({ error: 'Unauthorized to create content' });
-        }
-        if (userId !== req.user.id) {
-            return res.status(403).json({ error: 'Cannot create content for another user!' });
         }
 
         // 3. Create initial content document with 'processing' status

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "nodemon": "^3.1.3",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
+        "sinon": "^21.0.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "xoauth2": "^1.2.0"
@@ -636,6 +637,43 @@
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1524,7 +1562,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
       "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -4282,6 +4319,44 @@
         "node": ">=10"
       }
     },
+    "node_modules/sinon": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.0.tgz",
+      "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.8.0-beta.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
@@ -4709,6 +4784,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "nodemon": "^3.1.3",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
+    "sinon": "^21.0.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "xoauth2": "^1.2.0"

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -7,65 +7,83 @@ const User = require('../models/userModel');
 const jwt = require('jsonwebtoken');
 
 const { MongoMemoryServer } = require('mongodb-memory-server');
+const { Queue } = require('bullmq');
+const sinon = require('sinon');
 
 describe('Content API', function() {
-  this.timeout(30000); // Set timeout to 30 seconds to allow for compression
+  this.timeout(60000);
 
   let token;
   let userId;
   let mongoServer;
+  let runningServer;
+  let addStub;
 
   before(async () => {
     mongoServer = await MongoMemoryServer.create();
     const mongoUri = mongoServer.getUri();
-    await mongoose.connect(mongoUri);
+    process.env.MONGO_URI = mongoUri;
 
-    // Create a test user
     const user = await User.create({
       name: 'Test User',
       email: 'test@example.com',
       password: 'password',
-      role: 'creator' // or whatever role is needed to upload content
+      role: 'creator'
     });
     userId = user._id;
 
-    // Generate a token
     token = jwt.sign({ id: userId, role: user.role }, process.env.JWT_SECRET, {
       expiresIn: '1h',
     });
+
+    // Mock the queue
+    addStub = sinon.stub(Queue.prototype, 'add');
+
+    // Start the server for testing
+    runningServer = app.listen(0);
   });
 
   after(async () => {
-    // Clean up the test user
     await User.findByIdAndDelete(userId);
-    // Close the server connection
-    server.close();
-    // Close the mongoose connection
     await mongoose.disconnect();
     await mongoServer.stop();
+    addStub.restore(); // Restore the original method
+    if (runningServer) {
+      runningServer.close();
+    }
   });
 
-  it('should upload and compress a video', (done) => {
+  it('should create a content record and queue it for processing', (done) => {
+    const mockVideoData = {
+      public_id: 'test/video123',
+      url: 'http://res.cloudinary.com/demo/video/upload/test/video123.mp4',
+    };
+
+    const mockThumbnailData = {
+      public_id: 'test/thumb456',
+      url: 'http://res.cloudinary.com/demo/image/upload/test/thumb456.jpg',
+    };
+
     request(app)
       .post('/api/content')
       .set('Authorization', `Bearer ${token}`)
-      .field('title', 'Test Video')
-      .field('category', 'Test')
-      .field('description', 'A test video')
-      .field('credit', 'Test User')
-      .field('userId', userId.toString())
-      .field('previewStart', '0')
-      .field('previewEnd', '10')
-      .field('languageCode', 'en_us')
-      .attach('files', path.resolve(__dirname, 'test.mp4'))
-      .expect(201)
+      .send({
+        title: 'Test Video',
+        category: 'Test',
+        description: 'A test video',
+        credit: 'Test User',
+        previewStart: '0',
+        previewEnd: '10',
+        languageCode: 'en_us',
+        video: mockVideoData,
+        thumbnail: mockThumbnailData,
+      })
+      .expect(202)
       .end((err, res) => {
         if (err) return done(err);
-        // We can't easily check if the video was compressed,
-        // but a 201 response is a good indication that the process didn't crash.
-        // We can also check the response body for the video URL.
-        if (!res.body.video.includes('cloudinary')) {
-          return done(new Error('Video not uploaded to Cloudinary'));
+
+        if (res.body.status !== 'processing') {
+          return done(new Error('Content status should be "processing"'));
         }
         done();
       });


### PR DESCRIPTION
This commit resolves an authorization issue where users with the 'creator' role were unable to create content.

The `createContent` controller was incorrectly expecting a `userId` in the request body instead of using the authenticated user's ID from `req.user`. This has been corrected to use `req.user.id`, which fixes the bug and improves security by ensuring users can only create content for themselves.

Additionally, the associated test in `test/content.test.js` has been updated to reflect the current two-step, asynchronous upload process. It now mocks the Cloudinary data and the message queue, making the test more robust and independent of external services.