### PR TITLE
Fix: Add 'processing' to aiModerationStatus enum. This resolves a val…

### DIFF
--- a/models/contentModel.js
+++ b/models/contentModel.js
@@ -79,7 +79,7 @@ const contentSchema = new mongoose.Schema(
         },
         aiModerationStatus: {
             type: String,
-            enum: ['approved', 'rejected', 'needs_review', 'pending'],
+            enum: ['approved', 'rejected', 'needs_review', 'pending', 'processing'],
             default: 'pending',
         },
         aiModerationLabels: {


### PR DESCRIPTION
…idation error that occurred when creating new content. The `aiModerationStatus` is now correctly set to 'processing' on content creation.