### PR TITLE
Fix(media): Handle image uploads from memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "compression": "^1.8.0",
         "cors": "^2.8.5",
         "crypto": "^1.0.1",
+        "datauri": "^4.1.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-async-handler": "^1.2.0",
@@ -1482,6 +1483,19 @@
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
       "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
+    "node_modules/datauri": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/datauri/-/datauri-4.1.0.tgz",
+      "integrity": "sha512-y17kh32+I82G+ED9MNWFkZiP/Cq/vO1hN9+tSZsT9C9qn3NrvcBnh7crSepg0AQPge1hXx2Ca44s1FRdv0gFWA==",
+      "license": "MIT",
+      "dependencies": {
+        "image-size": "1.0.0",
+        "mimer": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2436,6 +2450,21 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
     },
+    "node_modules/image-size": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.0.tgz",
+      "integrity": "sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2894,6 +2923,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mimer/-/mimer-2.0.2.tgz",
+      "integrity": "sha512-izxvjsB7Ur5HrTbPu6VKTrzxSMBFBqyZQc6dWlZNQ4/wAvf886fD4lrjtFd8IQ8/WmZKdxKjUtqFFNaj3hQ52g==",
+      "license": "MIT",
+      "bin": {
+        "mimer": "bin/mimer"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/mimic-fn": {
@@ -3960,6 +4001,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/randombytes": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "compression": "^1.8.0",
     "cors": "^2.8.5",
     "crypto": "^1.0.1",
+    "datauri": "^4.1.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-async-handler": "^1.2.0",


### PR DESCRIPTION
This commit resolves a critical bug that caused image uploads to fail in production environments. The previous implementation relied on `req.file.path`, which is not available when using `multer.memoryStorage` or in environments with ephemeral filesystems.

The key changes include:
- Modified `userController.js` and `channelController.js` to process file uploads from memory buffers instead of file paths.
- Introduced the `datauri` library to convert file buffers into data URIs suitable for Cloudinary's upload API.
- Removed the unnecessary `fs` dependency and `fs.unlink` calls, as files are no longer written to the local disk.

These changes ensure that profile and channel banner image uploads are handled correctly and robustly, preventing crashes and improving the reliability of the application.