### PR TITLE
fix(channel): allow bannerImage update in updateChannelInfo

### DIFF
--- a/controllers/channelController.js
+++ b/controllers/channelController.js
@@ -79,7 +79,7 @@ const updateChannelInfo = asyncHandler(async (req, res) => {
     return res.status(403).json({ error: 'You are not authorized to update this channel' });
   }
 
-  const allowedFields = ['about', 'name', 'profileImage', 'instagram', 'tiktok', 'linkedin', 'twitter'];
+  const allowedFields = ['about', 'name', 'profileImage', 'bannerImage', 'instagram', 'tiktok', 'linkedin', 'twitter'];
   Object.keys(updates).forEach((key) => {
     if (allowedFields.includes(key)) {
       user[key] = updates[key] || user[key]; // Preserve existing value if update is empty
@@ -93,6 +93,7 @@ const updateChannelInfo = asyncHandler(async (req, res) => {
     name: user.name,
     about: user.about,
     profileImage: user.profileImage,
+    bannerImage: user.bannerImage,
     instagram: user.instagram,
     tiktok: user.tiktok,
     linkedin: user.linkedin,


### PR DESCRIPTION
The `updateChannelInfo` function was not allowing the `bannerImage` field to be updated. This change adds `bannerImage` to the list of allowed fields, enabling users to update their channel's banner image URL directly. The response object is also updated to include the `bannerImage` field.