### PR TITLE
feat: Automate highlight generation and add fetch routes

### DIFF
--- a/Routes/highlightRoute.js
+++ b/Routes/highlightRoute.js
@@ -1,54 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const {
-    createHighlight,
     getHighlightsByCreator,
     getRecentHighlights,
+    getAllHighlights,
 } = require('../controllers/highlightController');
 const { protect } = require('../middleware/authmiddleware');
-
-/**
- * @swagger
- * /api/highlights:
- *   post:
- *     summary: Create a new highlight
- *     description: Creates a new highlight for a video, specifying the start and end times.
- *     tags: [Highlights]
- *     security:
- *       - BearerAuth: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required:
- *               - contentId
- *               - startTime
- *               - endTime
- *             properties:
- *               contentId:
- *                 type: string
- *                 description: The ID of the content to create a highlight for.
- *               startTime:
- *                 type: number
- *                 description: The start time of the highlight in seconds.
- *               endTime:
- *                 type: number
- *                 description: The end time of the highlight in seconds.
- *     responses:
- *       201:
- *         description: Highlight created successfully.
- *       400:
- *         description: Bad request, missing required fields.
- *       401:
- *         description: Unauthorized, token is missing or invalid.
- *       403:
- *         description: Forbidden, user is not the owner of the content.
- *       404:
- *         description: Content not found.
- */
-router.route('/').post(protect, createHighlight);
 
 /**
  * @swagger
@@ -84,5 +41,18 @@ router.route('/creator/:creatorId').get(getHighlightsByCreator);
  *         description: A list of recent highlights.
  */
 router.route('/recent').get(getRecentHighlights);
+
+/**
+ * @swagger
+ * /api/highlights/all:
+ *   get:
+ *     summary: Get all highlights
+ *     description: Retrieves all highlights.
+ *     tags: [Highlights]
+ *     responses:
+ *       200:
+ *         description: A list of all highlights.
+ */
+router.route('/all').get(getAllHighlights);
 
 module.exports = router;

--- a/controllers/contentController.js
+++ b/controllers/contentController.js
@@ -276,7 +276,7 @@ const getContentById = asyncHandler(async (req, res) => {
         const highlight = await Highlight.findById(content.highlight);
         if (highlight) {
             contentData.highlight = highlight.toObject();
-            contentData.highlightUrl = `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/video/upload/so_${highlight.startTime},eo_${highlight.endTime}/${content.cloudinary_video_id}.mp4`;
+            contentData.highlightUrl = `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/video/upload/e_accelerate:50,so_${highlight.startTime},eo_${highlight.endTime}/${content.cloudinary_video_id}.mp4`;
         }
     }
 

--- a/controllers/highlightController.js
+++ b/controllers/highlightController.js
@@ -3,38 +3,6 @@ const Highlight = require('../models/highlightModel');
 const Content = require('../models/contentModel');
 const mongoose = require('mongoose');
 
-// @desc Create a new highlight
-// @route POST /api/highlights
-// @access Private
-const createHighlight = asyncHandler(async (req, res) => {
-    const { contentId, startTime, endTime } = req.body;
-    const userId = req.user.id;
-
-    if (!contentId || startTime === undefined || endTime === undefined) {
-        return res.status(400).json({ error: 'Content ID, start time, and end time are required.' });
-    }
-
-    const content = await Content.findById(contentId);
-    if (!content) {
-        return res.status(404).json({ error: 'Content not found.' });
-    }
-
-    if (content.user.toString() !== userId) {
-        return res.status(403).json({ error: 'You can only create highlights for your own content.' });
-    }
-
-    const highlight = await Highlight.create({
-        user: userId,
-        content: contentId,
-        startTime,
-        endTime,
-    });
-
-    await Content.findByIdAndUpdate(contentId, { highlight: highlight._id });
-
-    res.status(201).json(highlight);
-});
-
 // @desc Get all highlights for a specific creator
 // @route GET /api/highlights/creator/:creatorId
 // @access Public
@@ -57,8 +25,16 @@ const getRecentHighlights = asyncHandler(async (req, res) => {
     res.status(200).json(highlights);
 });
 
+// @desc Get all highlights
+// @route GET /api/highlights/all
+// @access Public
+const getAllHighlights = asyncHandler(async (req, res) => {
+    const highlights = await Highlight.find().sort({ createdAt: -1 }).populate('content', 'title thumbnail');
+    res.status(200).json(highlights);
+});
+
 module.exports = {
-    createHighlight,
     getHighlightsByCreator,
     getRecentHighlights,
+    getAllHighlights,
 };


### PR DESCRIPTION
This commit refactors the highlight generation process to be fully automated. When a creator uploads a new video, the system now automatically generates a 10-30 second highlight clip. This is achieved by adding new functionality to the `ai-service` to determine the video's duration and calculate a suitable highlight segment.

The `worker.js` file has been updated to orchestrate this process during video upload. It calls the new `ai-service` functions, creates a new `Highlight` document, and associates it with the content.

Additionally, the highlight video is now sped up using a Cloudinary transformation (`e_accelerate:50`), which is applied in the `contentController.js`.

Finally, the API has been updated to support the new automated workflow. The manual highlight creation endpoint (`POST /api/highlights`) has been removed, and a new endpoint (`GET /api/highlights/all`) has been added to fetch all highlights.