### PR TITLE
fix(highlight): Fetch video duration from Cloudinary

### DIFF
--- a/ai/ai-service.js
+++ b/ai/ai-service.js
@@ -162,6 +162,7 @@ class AIService {
         try {
             const result = await cloudinary.api.resource(publicId, {
                 resource_type: 'video',
+                image_metadata: true, // Requesting metadata to ensure duration is included
             });
             if (result && result.duration) {
                 console.log(`AI Service: Found duration: ${result.duration}`);


### PR DESCRIPTION
The video highlight generation was failing because the call to Cloudinary's API did not reliably return the video's duration.

This commit adds the `image_metadata: true` flag to the `cloudinary.api.resource` call in `ai/ai-service.js`.

This ensures the `duration` property is always present in the response, allowing the `generateHighlight` function to work as expected.