### PR TITLE
fix(worker): Load environment variables before all other modules

### DIFF
--- a/worker-manager.js
+++ b/worker-manager.js
@@ -1,6 +1,8 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
 const { Worker } = require('bullmq');
 const mongoose = require('mongoose');
-const dotenv = require('dotenv');
 const fs = require('fs');
 const path = require('path');
 const axios = require('axios');
@@ -10,8 +12,6 @@ const contentSchema = require('./models/contentModel');
 const userSchema = require('./models/userModel');
 const Highlight = require('./models/highlightModel');
 const aiService = require('./ai/ai-service');
-
-dotenv.config();
 
 const transporter = require('./utils/mailer');
 


### PR DESCRIPTION
The AssemblyAI API key was not being recognized in the worker process because `dotenv.config()` was called after the `aiService` module was imported.

This commit moves `dotenv.config()` to the top of `worker-manager.js` to ensure all environment variables are loaded before any other code execution. This makes the `ASSEMBLYAI_API_KEY` available when the `AIService` class is initialized.