### PR TITLE
feat: Add 30-second highlights and restrict visibility

### DIFF
--- a/Routes/highlightRoute.js
+++ b/Routes/highlightRoute.js
@@ -1,11 +1,55 @@
 const express = require('express');
 const router = express.Router();
 const {
+    createHighlight,
     getHighlightsByCreator,
     getRecentHighlights,
     getAllHighlights,
 } = require('../controllers/highlightController');
 const { protect } = require('../middleware/authmiddleware');
+
+/**
+ * @swagger
+ * /api/highlights:
+ *   post:
+ *     summary: Create a new highlight
+ *     description: Creates a new 30-second highlight for a video. This is only available to the owner of the content.
+ *     tags: [Highlights]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - contentId
+ *               - startTime
+ *               - endTime
+ *             properties:
+ *               contentId:
+ *                 type: string
+ *                 description: The ID of the content to create a highlight for.
+ *               startTime:
+ *                 type: number
+ *                 description: The start time of the highlight in seconds.
+ *               endTime:
+ *                 type: number
+ *                 description: The end time of the highlight in seconds. The duration must be exactly 30 seconds.
+ *     responses:
+ *       201:
+ *         description: Highlight created successfully.
+ *       400:
+ *         description: Invalid input, e.g., highlight is not 30 seconds, or a highlight already exists.
+ *       401:
+ *         description: Unauthorized, token is missing or invalid.
+ *       403:
+ *         description: Forbidden, user does not own the content.
+ *       404:
+ *         description: Content not found.
+ */
+router.route('/').post(protect, createHighlight);
 
 /**
  * @swagger

--- a/controllers/highlightController.js
+++ b/controllers/highlightController.js
@@ -3,6 +3,56 @@ const Highlight = require('../models/highlightModel');
 const Content = require('../models/contentModel');
 const mongoose = require('mongoose');
 
+// @desc    Create a new highlight
+// @route   POST /api/highlights
+// @access  Private
+const createHighlight = asyncHandler(async (req, res) => {
+    const { contentId, startTime, endTime } = req.body;
+    const userId = req.user.id;
+
+    if (typeof startTime === 'undefined' || typeof endTime === 'undefined') {
+        return res.status(400).json({ error: 'Start time and end time are required.' });
+    }
+
+    if (endTime - startTime !== 30) {
+        return res.status(400).json({ error: 'Highlight must be exactly 30 seconds long.' });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(contentId)) {
+        return res.status(400).json({ error: 'Invalid content ID.' });
+    }
+
+    const content = await Content.findById(contentId);
+
+    if (!content) {
+        return res.status(404).json({ error: 'Content not found.' });
+    }
+
+    // Ensure the user creating the highlight is the owner of the content
+    if (content.user.toString() !== userId) {
+        return res.status(403).json({ error: 'User not authorized to create a highlight for this content.' });
+    }
+
+    // Check if a highlight already exists for this content
+    if (content.highlight) {
+        return res.status(400).json({ error: 'A highlight already exists for this content.' });
+    }
+
+    const highlight = new Highlight({
+        user: userId,
+        content: contentId,
+        startTime,
+        endTime,
+    });
+
+    const createdHighlight = await highlight.save();
+
+    content.highlight = createdHighlight._id;
+    await content.save();
+
+    res.status(201).json(createdHighlight);
+});
+
 // @desc Get all highlights for a specific creator
 // @route GET /api/highlights/creator/:creatorId
 // @access Public
@@ -13,7 +63,12 @@ const getHighlightsByCreator = asyncHandler(async (req, res) => {
         return res.status(400).json({ error: 'Invalid creator ID.' });
     }
 
-    const highlights = await Highlight.find({ user: creatorId }).populate('content', 'title thumbnail');
+    // Find approved content for the creator
+    const approvedContentIds = await Content.find({ user: creatorId, isApproved: true }).distinct('_id');
+
+    const highlights = await Highlight.find({ user: creatorId, content: { $in: approvedContentIds } })
+        .populate('content', 'title thumbnail');
+
     res.status(200).json(highlights);
 });
 
@@ -21,7 +76,14 @@ const getHighlightsByCreator = asyncHandler(async (req, res) => {
 // @route GET /api/highlights/recent
 // @access Public
 const getRecentHighlights = asyncHandler(async (req, res) => {
-    const highlights = await Highlight.find().sort({ createdAt: -1 }).limit(10).populate('content', 'title thumbnail');
+    // Find IDs of all approved content
+    const approvedContentIds = await Content.find({ isApproved: true }).distinct('_id');
+
+    const highlights = await Highlight.find({ content: { $in: approvedContentIds } })
+        .sort({ createdAt: -1 })
+        .limit(10)
+        .populate('content', 'title thumbnail');
+
     res.status(200).json(highlights);
 });
 
@@ -29,11 +91,18 @@ const getRecentHighlights = asyncHandler(async (req, res) => {
 // @route GET /api/highlights/all
 // @access Public
 const getAllHighlights = asyncHandler(async (req, res) => {
-    const highlights = await Highlight.find().sort({ createdAt: -1 }).populate('content', 'title thumbnail');
+    // Find IDs of all approved content
+    const approvedContentIds = await Content.find({ isApproved: true }).distinct('_id');
+
+    const highlights = await Highlight.find({ content: { $in: approvedContentIds } })
+        .sort({ createdAt: -1 })
+        .populate('content', 'title thumbnail');
+
     res.status(200).json(highlights);
 });
 
 module.exports = {
+    createHighlight,
     getHighlightsByCreator,
     getRecentHighlights,
     getAllHighlights,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Server application for Playmood",
   "main": "server.js",
   "scripts": {
-    "test": "NODE_ENV=test JWT_SECRET=test GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test GOOGLE_CALLBACK_URL=test mocha test/content.test.js",
+    "test": "NODE_ENV=test JWT_SECRET=test GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test GOOGLE_CALLBACK_URL=test CLOUDINARY_API_KEY=test CLOUDINARY_API_SECRET=test mocha test/content.test.js",
     "start": "nodemon server.js",
     "server": "server.js"
   },


### PR DESCRIPTION
This commit introduces two new features related to video highlights:

1.  **30-Second Highlights:** Creators can now generate 30-second highlights from their videos. A new endpoint, `POST /api/highlights`, has been added to support this functionality. The controller logic ensures that only content owners can create highlights and that each piece of content can have only one highlight.

2.  **Highlight Visibility:** The visibility of highlights is now restricted to content that has been approved. The `getHighlightsByCreator`, `getRecentHighlights`, and `getAllHighlights` functions have been updated to filter out highlights associated with unapproved content.

Additionally, a minor fix was made to the test suite to ensure that all tests pass. The `package.json` was updated to include the necessary environment variables for the Cloudinary signature generation test.