### PR TITLE
Fix: Ensure content from non-admin users is not auto-approved

### DIFF
--- a/worker-manager.js
+++ b/worker-manager.js
@@ -196,9 +196,7 @@ const processUpload = async (job) => {
         content.contentEmbedding = contentEmbedding;
 
         let isApproved = content.user.role === 'admin';
-        if (moderation.status === 'approved' && !isApproved) {
-            isApproved = true;
-        } else if (moderation.status === 'rejected') {
+        if (moderation.status === 'rejected') {
             isApproved = false;
             content.rejectionReason = `Content automatically rejected by AI due to: ${moderation.labels.join(', ')}`;
         }


### PR DESCRIPTION
This commit fixes a bug where content created by non-admin users was being automatically approved if the AI moderation status was 'approved'. The logic in `worker-manager.js` has been corrected to ensure that `isApproved` is only set to `true` if the user is an admin.