### PR TITLE
Fix: Remove deprecated QueueScheduler and improve error logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,7 +116,7 @@ if (require.main === module) {
       server.listen(port, () => console.log(`Server started on port ${port}`));
     })
     .catch((error) => {
-      console.error('Failed to connect to MongoDB:', error.message);
+      console.error('Failed to start server:', error);
       process.exit(1);
     });
 }

--- a/worker-manager.js
+++ b/worker-manager.js
@@ -1,7 +1,7 @@
 const dotenv = require('dotenv');
 dotenv.config();
 
-const { Worker, Queue, QueueScheduler } = require('bullmq');
+const { Worker, Queue } = require('bullmq');
 const mongoose = require('mongoose');
 const fs = require('fs');
 const path = require('path');
@@ -66,7 +66,6 @@ const redisConnectionOpts = {
 let uploadWorker;
 let analyticsWorker;
 let analyticsQueue;
-let analyticsScheduler;
 
 const startWorker = () => {
     if (uploadWorker) {
@@ -96,7 +95,6 @@ const startWorker = () => {
 
     // Schedule the analytics job
     analyticsQueue = new Queue('analytics', { connection: redisConnectionOpts.connection });
-    analyticsScheduler = new QueueScheduler('analytics', { connection: redisConnectionOpts.connection });
 
     // Remove any existing repeatable jobs to avoid duplicates
     analyticsQueue.getRepeatableJobs().then(jobs => {
@@ -126,7 +124,6 @@ const gracefulShutdown = async () => {
     if (uploadWorker) await uploadWorker.close();
     if (analyticsWorker) await analyticsWorker.close();
     if (analyticsQueue) await analyticsQueue.close();
-    if (analyticsScheduler) await analyticsScheduler.close();
     await mongoose.disconnect();
     process.exit(0);
 };


### PR DESCRIPTION
The application was crashing on startup due to a `QueueScheduler is not a constructor` error. This was caused by using the deprecated `QueueScheduler` class from `bullmq`.

This commit removes all usage of `QueueScheduler` from `worker-manager.js`. In `bullmq` v2.0 and later, the `Worker` class automatically handles scheduled and repeatable jobs, so a separate scheduler is no longer required.

Additionally, the error logging in `server.js` has been improved to provide more informative messages during startup failures.