### PR TITLE
feat: Create highlight on content approval

### DIFF
--- a/controllers/contentController.js
+++ b/controllers/contentController.js
@@ -12,6 +12,7 @@ const path = require('path');
 const uploadQueue = require('../config/queue');
 const { getWss } = require('../websocket');
 const WebSocket = require('ws');
+const { createHighlightForContent } = require('../worker-manager');
 
 // @desc Get All Content
 // @route GET /api/content 
@@ -561,6 +562,11 @@ const approveContent = asyncHandler(async (req, res) => {
         content.isApproved = true;
         content.rejectionReason = undefined; // Clear rejection reason
         await content.save();
+
+        // If the content is approved and does not already have a highlight, create one.
+        if (content.isApproved && !content.highlight) {
+            await createHighlightForContent(content);
+        }
 
         // Populate user details
         const populatedContent = await contentSchema.findById(id).populate('user', 'name profileImage');


### PR DESCRIPTION
Refactored the highlight creation logic into a reusable function, `createHighlightForContent`, in `worker-manager.js`.

This new function is now called from the `approveContent` controller, ensuring that a highlight is generated automatically when an admin approves content.

The `processUpload` worker has also been updated to use this new function, maintaining the existing highlight creation functionality for new uploads.

Added a new test case to verify that approving content successfully triggers highlight creation and links it correctly.