### PR TITLE
fix(content): Add 'processed' to status enum in content model

### DIFF
--- a/models/contentModel.js
+++ b/models/contentModel.js
@@ -59,7 +59,7 @@ const contentSchema = new mongoose.Schema(
         },
         status: {
             type: String,
-            enum: ['processing', 'completed', 'failed'],
+            enum: ['processing', 'processed', 'completed', 'failed'],
             default: 'processing',
         },
         captions: [


### PR DESCRIPTION
The content processing worker was attempting to set the content status to 'processed', but this value was not included in the Mongoose schema's enum for the `status` field. This caused a validation error, preventing the content from being updated correctly.

This commit adds 'processed' to the list of valid statuses in the `contentModel`, resolving the validation error and allowing the worker to function as expected.